### PR TITLE
Fixed syntax errors in dRNAas_single.py

### DIFF
--- a/dRNAas.py
+++ b/dRNAas.py
@@ -26,7 +26,7 @@ rule generateEvents2:
         "AlternativeSplicing/localAS"
     output:
         "AlternativeSplicing/localAS/allevents.ioe"
-    shell：
+    shell:
         "awk 'FNR==1 && NR!=1 { while (/^<header>/) getline; } 1 {print}' {input}/*.ioe > output[0]"
 
 rule joinFilesCond1:
@@ -35,7 +35,7 @@ rule joinFilesCond1:
         {S1R2}
     output:
         "AlternativeSplicing/localAS/Condition1"
-    shell：
+    shell:
         "suppa.py joinFiles -f tpm -i {input[0]} {input[1]} -o {output}"
 
 rule joinFilesCond1:
@@ -44,7 +44,7 @@ rule joinFilesCond1:
         {S2R2}
     output:
         "AlternativeSplicing/localAS/Condition2"
-    shell：
+    shell:
         "suppa.py joinFiles -f tpm -i {input[0]} {input[1]} -o {output}"
 
 rule PSI_Con1:
@@ -53,7 +53,7 @@ rule PSI_Con1:
         "AlternativeSplicing/localAS/Condition1"
     output:
         "AlternativeSplicing/localAS/Condition1"
-    shell：
+    shell:
         "suppa.py psiPerEvent --ioe-file {input[0]} --expression-file {input[1]}.tpm -o {output}"
 
 rule PSI_Con2:
@@ -62,7 +62,7 @@ rule PSI_Con2:
         "AlternativeSplicing/localAS/Condition2"
     output:
         "AlternativeSplicing/localAS/Condition2"
-    shell：
+    shell:
         "suppa.py psiPerEvent --ioe-file {input[0]} --expression-file {input[1]}.tpm -o {output}"
 
 rule diffsplice:
@@ -74,7 +74,7 @@ rule diffsplice:
         "AlternativeSplicing/localAS/Condition2"
     output:
         "AlternativeSplicing/localAS/Con1vs2"
-    shell： 
+    shell: 
         "suppa.py diffSplice --method empirical --input {input[0]} --psi {input[1]}.psi {input[2]}.psi --tpm {input[3]}.tpm {input[4]}.tpm --area 1000 --lower-bound 0.05 -gc -o {output}"
 
 rule cluster:

--- a/dRNAas_single.smk
+++ b/dRNAas_single.smk
@@ -37,7 +37,7 @@ rule generateEvents2:
         #{S1R2}
 #    output:
 #        "AlternativeSplicing/localAS/Condition1"
-#    shell：
+#    shell:
 #        "suppa.py joinFiles -f tpm -i {input[0]} {input[1]} -o {output}"
 
 #rule joinFilesCond1:
@@ -46,7 +46,7 @@ rule generateEvents2:
 #        {S2R2}
 #    output:
 #        "AlternativeSplicing/localAS/Condition2"
-#    shell：
+#    shell:
 #        "suppa.py joinFiles -f tpm -i {input[0]} {input[1]} -o {output}"
 
 rule PSI_Con1:
@@ -76,7 +76,7 @@ rule PSI_Con2:
 #        "AlternativeSplicing/localAS/Condition2"
 #    output:
 #        "AlternativeSplicing/localAS/Con1vs2"
-#    shell： 
+#    shell: 
 #        "suppa.py diffSplice --method empirical --input {input[0]} --psi {input[1]}.psi {input[2]}.psi --tpm {input[3]}.tpm {input[4]}.tpm --area 1000 --lower-bound 0.05 -gc -o {output}"
 
 #rule cluster:

--- a/dRNAas_single.smk
+++ b/dRNAas_single.smk
@@ -28,7 +28,7 @@ rule generateEvents2:
         "AlternativeSplicing/localAS"
     output:
         "AlternativeSplicing/localAS/allevents.ioe"
-    shell：
+    shell:
         "awk 'FNR==1 && NR!=1 { while (/^<header>/) getline; } 1 {print}' {input}/*.ioe > output[0]"
 
 #rule joinFilesCond1:
@@ -55,7 +55,7 @@ rule PSI_Con1:
         {S1R1}
     output:
         "AlternativeSplicing/localAS/Condition1"
-    shell：
+    shell:
         "suppa.py psiPerEvent --ioe-file {input[0]} --expression-file {input[1]}.tpm -o {output}"
 
 rule PSI_Con2:
@@ -64,7 +64,7 @@ rule PSI_Con2:
         {S2R1}
     output:
         "AlternativeSplicing/localAS/Condition2"
-    shell：
+    shell:
         "suppa.py psiPerEvent --ioe-file {input[0]} --expression-file {input[1]}.tpm -o {output}"
 
 #rule diffsplice:
@@ -77,7 +77,7 @@ rule PSI_Con2:
 #    output:
 #        "AlternativeSplicing/localAS/Con1vs2"
 #    shell： 
-3        "suppa.py diffSplice --method empirical --input {input[0]} --psi {input[1]}.psi {input[2]}.psi --tpm {input[3]}.tpm {input[4]}.tpm --area 1000 --lower-bound 0.05 -gc -o {output}"
+#        "suppa.py diffSplice --method empirical --input {input[0]} --psi {input[1]}.psi {input[2]}.psi --tpm {input[3]}.tpm {input[4]}.tpm --area 1000 --lower-bound 0.05 -gc -o {output}"
 
 #rule cluster:
 #    input:

--- a/dRNAas_single.smk
+++ b/dRNAas_single.smk
@@ -21,7 +21,7 @@ rule generateEvents:
     output:
         "AlternativeSplicing/localAS"
     shell:
-        "mkdir AlternativeSplicing | mkdir AlternativeSplicing/localAS | suppa.py generateEvents -i {input} -o {output}/local -f ioe -e {SE,SS,MX,RI,FL}"
+        "mkdir AlternativeSplicing | mkdir AlternativeSplicing/localAS | suppa.py generateEvents -i {input} -o {output}/local -f ioe -e {{SE,SS,MX,RI,FL}}"
 
 rule generateEvents2:
     input:
@@ -29,7 +29,7 @@ rule generateEvents2:
     output:
         "AlternativeSplicing/localAS/allevents.ioe"
     shell:
-        "awk 'FNR==1 && NR!=1 { while (/^<header>/) getline; } 1 {print}' {input}/*.ioe > output[0]"
+        "awk 'FNR==1 && NR!=1 {{ while (/^<header>/) getline; }} 1 {{print}}' {input}/*.ioe > {output[0]}"
 
 #rule joinFilesCond1:
 #    input:

--- a/dRNAmain.smk
+++ b/dRNAmain.smk
@@ -20,7 +20,7 @@ rule slow5_f2s:
         "{fast5}"
     output:
         "{example}/analysis/slow5/midbolw5_dir"
-    shell：
+    shell:
         "slow5tools f2s {input} -d {output}  -p 8"
 
 rule slow5_merge:

--- a/dRNAmodif_1.py
+++ b/dRNAmodif_1.py
@@ -18,7 +18,7 @@ rule eventalign:
         "{ref}"
     output:
         expand("{example}/analysis/modification/{example}_eventalign.tsv",example=EXA)
-    shell：
+    shell:
         "nanopolish index {input[0]} --slow5 {input[1]}| nanopolish eventalign --reads {input[0]} --bam {input[2]}  --genome {input[3]} --print-read-names --scale-events --samples > {output}"
 
 

--- a/dRNAmodif_2.py
+++ b/dRNAmodif_2.py
@@ -26,7 +26,7 @@ rule sampcomp:
     params:
         {sample1},
         {sample2}
-    shell：
+    shell:
         "nanocompore sampcomp --file_list1 {input[0]} , {input[1]} --file_list2 {input[2]} , {input[3]} --label1 {params[0]} --label2 {params[1]} --fasta {input[4]} --outpath {output}"
 
 rule follow:


### PR DESCRIPTION
- 3 instances of "The character U+ff1a "：" could be confused with the ASCII character U+003a ":", which is more common in source code.".
- 1 instance of "3" instead of "#".
- I think .smk is more appropriate extension for snakemake files than .py.